### PR TITLE
Fix integration tests: replace unavailable test video URL and fix APIC tag assertion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,4 @@ import pytest
 
 # 統合テスト用の短い公開動画 URL
 # Short public domain video URL for integration tests.
-TEST_VIDEO_URL = "https://www.youtube.com/watch?v=BaW_jenozKc"
+TEST_VIDEO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -41,7 +41,7 @@ def test_download_audio_mp3(tmp_path: pathlib.Path) -> None:
     out = _run_download(tmp_path, DownloadMode.AUDIO_MP3)
     assert out.stat().st_size > 0
     tags = ID3(str(out))
-    assert "APIC:" in tags, "Thumbnail should be embedded as APIC tag"
+    assert any(k.startswith("APIC:") for k in tags), "Thumbnail should be embedded as APIC tag"
 
 
 @pytest.mark.integration

--- a/tests/mock/test_expand_ytdlp.py
+++ b/tests/mock/test_expand_ytdlp.py
@@ -49,9 +49,7 @@ def test_init_invalid_download_mode(tmp_path: pathlib.Path) -> None:
         (DownloadMode.VIDEO_BEST_VP9, "mp4"),
     ],
 )
-def test_init_ext_by_mode(
-    tmp_path: pathlib.Path, mode: DownloadMode, expected_ext: str
-) -> None:
+def test_init_ext_by_mode(tmp_path: pathlib.Path, mode: DownloadMode, expected_ext: str) -> None:
     """DownloadMode ごとに正しい拡張子が設定されること。"""
     with patch("yt_dlp_expand.main_script.check_is_pc", return_value=True):
         obj = ExpandYt_dlp(mode, "https://example.com/", tmp_path)
@@ -59,7 +57,7 @@ def test_init_ext_by_mode(
 
 
 # -------------------------------------------------------------------
-# run() のテスト（各メソッドをモック）
+# run() のテスト(各メソッドをモック)
 # -------------------------------------------------------------------
 
 
@@ -116,9 +114,7 @@ def test_run_calls_all_methods_mode1(tmp_path: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize("mode", [2, 3, 4])
-def test_run_calls_merge_mp4_for_video_modes(
-    tmp_path: pathlib.Path, mode: int
-) -> None:
+def test_run_calls_merge_mp4_for_video_modes(tmp_path: pathlib.Path, mode: int) -> None:
     """mode 2/3/4 (video) で merge_file_thumbnail_mp4 が呼ばれること。"""
     obj = _make_obj(tmp_path, mode)
 


### PR DESCRIPTION
## Summary

- **テスト動画 URL の変更**: `BaW_jenozKc` は削除済みで存在しないため、Rick Astley の "Never Gonna Give You Up" (`dQw4w9WgXcQ`) に変更。720p h264 + mp4a 音声を含む全5ダウンロードモードに対応した動画。
- **APIC タグアサーションの修正**: `merge_file_thumbnail_mp3` は `desc="Cover"` でタグを作成するため mutagen 上のキーは `APIC:Cover` となる。`"APIC:" in tags`（完全一致）から `any(k.startswith("APIC:") for k in tags)`（前方一致）に修正。
- Python 3.10 の venv が壊れていたため Python 3.13 で再作成し、全5件の統合テストがパスすることを確認済み（約66秒）。

## Test plan

- [x] `pytest -m integration tests/integration/` — 5 passed in 66s